### PR TITLE
Fix Collections issue, optimize get_meta_items

### DIFF
--- a/rmapy/api.py
+++ b/rmapy/api.py
@@ -37,6 +37,7 @@ class Client(object):
 
     def __init__(self):
         config = load()
+        self.meta_items = None
         if "devicetoken" in config:
             self.token_set["devicetoken"] = config["devicetoken"]
         if "usertoken" in config:
@@ -163,7 +164,7 @@ class Client(object):
         else:
             return False
 
-    def get_meta_items(self) -> Collection:
+    def get_meta_items(self, use_cache: bool = False) -> Collection:
         """Returns a new collection from meta items.
 
         It fetches all meta items from the Remarkable Cloud and stores them
@@ -174,13 +175,16 @@ class Client(object):
                 Cloud
         """
 
+        if use_cache and not (self.meta_items is None):
+            return self.meta_items
+
         response = self.request("GET", "/document-storage/json/2/docs")
-        collection = Collection()
+        self.meta_items = Collection()
         log.debug(response.text)
         for item in response.json():
-            collection.add(item)
+            self.meta_items.add(item)
 
-        return collection
+        return self.meta_items
 
     def get_doc(self, _id: str) -> Optional[DocumentOrFolder]:
         """Get a meta item by ID

--- a/rmapy/collections.py
+++ b/rmapy/collections.py
@@ -15,9 +15,9 @@ class Collection(object):
         items: A list containing the items.
     """
 
-    items: List[DocumentOrFolder] = []
-
     def __init__(self, *items: List[DocumentOrFolder]):
+        self.items: List[DocumentOrFolder] = []
+
         for i in items:
             self.items.append(i)
 

--- a/rmapy/meta.py
+++ b/rmapy/meta.py
@@ -56,7 +56,7 @@ class Meta(object):
             "ID": self.ID,
             "Version": self.Version,
             "Message": self.Message,
-            "Succes": self.Success,
+            "Success": self.Success,
             "BlobURLGet": self.BlobURLGet,
             "BlobURLGetExpires": self.BlobURLGetExpires,
             "BlobURLPut": self.BlobURLPut,


### PR DESCRIPTION
`Collections` had `items` as a class variable, which meant that when `Client` was creating new collections and returning them, it was really appending the results onto previous results. This lead to a bunch of downstream issues.

I added the option to `get_meta_items` from a cache, so that if you don't need to send a fresh HTML request you don't need to. It defaults to `False` to main backwards compatibility.