### PR TITLE
Ignore missing thumbnail files

### DIFF
--- a/rmapy/document.py
+++ b/rmapy/document.py
@@ -9,7 +9,7 @@ from logging import getLogger
 from requests import Response
 from .meta import Meta
 
-log = getLogger(__name__)
+log = getLogger("rmapy")
 BytesOrString = TypeVar("BytesOrString", BytesIO, str)
 
 


### PR DESCRIPTION
For some reason, my Remarkable Cloud files seem to not have thumbnails. This
causes `rmapy.api.Client.download` to fail with a `KeyError` when it tries to
open the (missing) thumbnail file.

I've verified that there really don't seem to be any thumbnails -- and not that
it's just a different name -- by inspecting the zipfile manually.

I'm using a Remarkable 2; maybe that's the difference?

Thanks for the API library, super useful!