### PR TITLE
Ignore missing thumbnails during dump

### DIFF
--- a/rmapy/document.py
+++ b/rmapy/document.py
@@ -261,8 +261,12 @@ class ZipDocument(object):
                 zf.writestr(f"{self.ID}/{page.order}-metadata.json",
                             json.dumps(page.metadata))
                 page.page.seek(0)
-                zf.writestr(f"{self.ID}.thumbnails/{page.order}.jpg",
-                            page.thumbnail.read())
+                try:
+                    zf.writestr(f"{self.ID}.thumbnails/{page.order}.jpg",
+                                page.thumbnail.read())
+                except AttributeError:
+                    log.debug(f"missing thumbnail during dump: {self.ID}: {page.order}")
+                    pass
         if isinstance(file, BytesIO):
             file.seek(0)
 


### PR DESCRIPTION
Resolves an AttributeError raised due to missing thumbnails when dumping a ZipDocument from the Remarkable 2

Related to #9