### PR TITLE
Use PageIDs for saving pages #17

### DIFF
--- a/rmapy/document.py
+++ b/rmapy/document.py
@@ -191,6 +191,7 @@ class ZipDocument(object):
         if not _id:
             _id = str(uuid4())
         self.ID = _id
+        self.rm = []
         if doc:
             ext = doc[-4:]
             if ext.endswith("pdf"):


### PR DESCRIPTION
PR for issue #17 

Changes: 
- Save `.metadata` in zip file. Some information can be extracted from the Document class
- Clean rm pages when initializing ZipDocument fixing issues where it saved pages from old documents
- Use PageID as document name to save pages.

EDIT: Although I've merged master branch several times to my branch and there are no conflicts, and I have the conflicts resolved, IDK why it's still conflicting in this PR. 