### PR TITLE
Updated the API URL to new domain name

### DIFF
--- a/rmapy/const.py
+++ b/rmapy/const.py
@@ -1,7 +1,7 @@
 RFC3339Nano = "%Y-%m-%dT%H:%M:%SZ"
 USER_AGENT = "rmapy"
 BASE_URL = "https://document-storage-production-dot-remarkable-production.appspot.com"  # noqa
-DEVICE_TOKEN_URL = "https://my.remarkable.com/token/json/2/device/new"
-USER_TOKEN_URL = "https://my.remarkable.com/token/json/2/user/new"
+DEVICE_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/device/new"
+USER_TOKEN_URL = "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/user/new"
 DEVICE = "desktop-windows"
 SERVICE_MGR_URL = "https://service-manager-production-dot-remarkable-production.appspot.com"  # noqa


### PR DESCRIPTION
This has changed recently and the old domain no longer works. Currently HTML ends up in the configuration file instead of tokens, I've tested this be reregistering my device with this code present and all works again.

This should resolve https://github.com/subutux/rmapy/issues/23