### PR TITLE
fix : Update myRemarkable token url in error message

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -7,7 +7,7 @@ are re-used because we use the same storage location & format.
 If not, you'll need to register the client as a new device on `my remarkable`_.
 
 
-.. _my remarkable: https://my.remarkable.com/connect/remarkable
+.. _my remarkable: https://my.remarkable.com/device/desktop/connect
 
 .. _rmapi: https://github.com/juruen/rmapi
 

--- a/rmapy/api.py
+++ b/rmapy/api.py
@@ -95,12 +95,12 @@ class Client(object):
         """Registers a device on the Remarkable Cloud.
 
         This uses a unique code the user gets from
-        https://my.remarkable.com/connect/remarkable to register a new device
+        https://my.remarkable.com/device/desktop/connect to register a new device
         or client to be able to execute api calls.
 
         Args:
             code: A unique One time code the user can get
-                at https://my.remarkable.com/connect/remarkable .
+                at https://my.remarkable.com/device/desktop/connect .
         Returns:
             True
         Raises:


### PR DESCRIPTION
Updates the URL from myRemarkable on which one can generate a new token