### PR TITLE
Changed authentication url, now matching rmapi authentication

### DIFF
--- a/rmapy/const.py
+++ b/rmapy/const.py
@@ -1,6 +1,6 @@
 RFC3339Nano = "%Y-%m-%dT%H:%M:%SZ"
 USER_AGENT = "rmapy"
-AUTH_BASE_URL = "https://webapp-production-dot-remarkable-production.appspot.com"
+AUTH_BASE_URL = "https://webapp-prod.cloud.remarkable.engineering"
 BASE_URL = "https://document-storage-production-dot-remarkable-production.appspot.com"  # noqa
 DEVICE_TOKEN_URL = AUTH_BASE_URL + "/token/json/2/device/new"
 USER_TOKEN_URL = AUTH_BASE_URL + "/token/json/2/user/new"


### PR DESCRIPTION
Fixes authentication error. Before this fix the remarkable cloud servers responded with "500: internal server error", when calling `register_device(code)`.